### PR TITLE
new:dev: Support node-level attributes for PurchaseOrderRequest

### DIFF
--- a/lib/cxml/address.rb
+++ b/lib/cxml/address.rb
@@ -11,6 +11,8 @@ module CXML
     attr_accessor :postal_code
     attr_accessor :country
     attr_accessor :email
+    attr_accessor :iso_country_code
+    attr_accessor :address_id
 
     def initialize(data = {})
       return unless data.is_a?(Hash) && !data.empty?
@@ -23,10 +25,12 @@ module CXML
       @postal_code = data['PostalAddress']['PostalCode']
       @country = data['PostalAddress']['Country']
       @email = data['Email']
+      @iso_country_code = data['isoCountryCode']
+      @address_id = data['addressID']
     end
 
     def render(node)
-      node.Address do |n|
+      node.Address(node_attributes) do |n|
         n.Name(name)
         n.PostalAddress do |pa|
           pa.DeliverTo(deliver_to)
@@ -38,6 +42,15 @@ module CXML
         end
         n.Email(email)
       end
+    end
+
+    private
+
+    def node_attributes
+      {
+        'isoCountryCode' => iso_country_code,
+        'addressID' => address_id
+      }
     end
   end
 end

--- a/lib/cxml/item_out.rb
+++ b/lib/cxml/item_out.rb
@@ -8,6 +8,7 @@ module CXML
     attr_accessor :quantity
     attr_accessor :distribution
     attr_accessor :comments
+    attr_accessor :line_number
 
     def initialize(data = {})
       return unless data.is_a?(Hash) && !data.empty?
@@ -17,6 +18,7 @@ module CXML
       @quantity = data['quantity']
       @distribution = CXML::Distribution.new(data['Distribution'])
       @comments = data['Comments']
+      @line_number = data['lineNumber']
     end
 
     def item_id?
@@ -30,12 +32,21 @@ module CXML
     def render(node)
       return unless item_id? && item_detail?
 
-      node.ItemOut('quantity' => quantity) do
+      node.ItemOut(node_attributes) do
         item_id.render(node)
         item_detail.render(node)
         distribution.render(node)
         node.Comments(@comments)
       end
+    end
+
+    private
+
+    def node_attributes
+      {
+        'quantity' => quantity,
+        'lineNumber' => line_number
+      }
     end
   end
 end

--- a/lib/cxml/order_request_header.rb
+++ b/lib/cxml/order_request_header.rb
@@ -8,6 +8,9 @@ module CXML
     attr_accessor :bill_to
     attr_accessor :contact
     attr_accessor :comments
+    attr_accessor :order_id
+    attr_accessor :order_date
+    attr_accessor :type
 
     def initialize(data = {})
       return unless data.is_a?(Hash) && !data.empty?
@@ -16,16 +19,29 @@ module CXML
       @ship_to = CXML::Address.new(data['ShipTo']['Address'])
       @bill_to = CXML::Address.new(data['BillTo']['Address'])
       @contact = CXML::Contact.new(data['Contact'])
+      @order_id = data['orderID']
+      @order_date = data['orderDate']
+      @type = data['type'] || 'new'
       @comments = data['Comments']
     end
 
     def render(node)
-      node.OrderRequestHeader do |n|
+      node.OrderRequestHeader(node_attributes) do |n|
         n.ShipTo { ship_to.render(n) }
         n.BillTo { bill_to.render(n) }
         contact.render(node)
         n.Comments(comments)
       end
+    end
+
+    private
+
+    def node_attributes
+      {
+        'orderID' => order_id,
+        'orderDate' => order_date,
+        'type' => type
+      }
     end
   end
 end

--- a/spec/purchase_order_request_spec.rb
+++ b/spec/purchase_order_request_spec.rb
@@ -23,4 +23,11 @@ describe CXML::OrderRequest do
       order_request_output_data['ItemOut'].length.should eq 2
     end
   end
+  describe '#initialize' do
+    it 'sets the required nodes' do
+      order_request.order_request_header.should_not be_nil
+      order_request.order_request_header.order_id.should_not be_nil
+      order_request.items_out.first.should_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
These node attributes were being dropped but we need them! The order ID
and line numbers are important when communicating back an invoice and
order reference info.