### PR TITLE
Fix bug where a `<![CDATA[...]]>` tag errored on parsing

### DIFF
--- a/lib/cxml/parser.rb
+++ b/lib/cxml/parser.rb
@@ -45,6 +45,8 @@ module CXML
     private
 
     def node_to_hash(node) # rubocop:disable Metrics/AbcSize
+      return node.value if node.is_a?(Ox::CData)
+
       return node if node.is_a? String
       return node.nodes.first if node.nodes.all?(String) && node.attributes.empty?
 
@@ -54,7 +56,7 @@ module CXML
         next acc if child_node.is_a?(Ox::Comment)
 
         node_hash = {}
-        name = child_node.is_a?(String) ? :content : child_node.value
+        name = child_node.is_a?(String) || child_node.is_a?(Ox::CData) ? :content : child_node.value
         node_hash[underscore_key(name)] = node_to_hash(child_node)
         acc.merge(node_hash) do |_key, val1, val2|
           [val1, val2].flatten

--- a/spec/fixtures/item_in.xml
+++ b/spec/fixtures/item_in.xml
@@ -4,7 +4,7 @@
     <SupplierPartAuxiliaryID>lkajsdflsdf</SupplierPartAuxiliaryID>
   </ItemID>
   <ItemDetail>
-    <Description xml:lang="en">AGENDA MAGAZINE RACK A4 CHARCOAL 25990</Description>
+    <Description xml:lang="en"><![CDATA[AGENDA MAGAZINE RACK A4 CHARCOAL 25990]]></Description>
     <UnitOfMeasure>EA</UnitOfMeasure>
     <UnitPrice> <Money currency="GBP">5.35</Money> </UnitPrice>
     <Classification domain="UNSPSC">44000000</Classification>


### PR DESCRIPTION
Currently, if the cxml passed in included a `<![CDATA[...]]>` tag
The parser would error out with this NoMethodError:

```
NoMethodError:
        undefined method `nodes' for #<Ox::CData:0x00007fee436eb070>
```

I have fixed it such that the CDATA tag returns its value in the :content
for the parent tag.