### PR TITLE
fix:dev: Fix bug where a `<![CDATA[...]]>` tag errored on parsing

### DIFF
--- a/spec/fixtures/item_in.xml
+++ b/spec/fixtures/item_in.xml
@@ -4,7 +4,7 @@
     <SupplierPartAuxiliaryID>lkajsdflsdf</SupplierPartAuxiliaryID>
   </ItemID>
   <ItemDetail>
-    <Description xml:lang="en">AGENDA MAGAZINE RACK A4 CHARCOAL 25990</Description>
+    <Description xml:lang="en"><![CDATA[AGENDA MAGAZINE RACK A4 CHARCOAL 25990]]></Description>
     <UnitOfMeasure>EA</UnitOfMeasure>
     <UnitPrice> <Money currency="GBP">5.35</Money> </UnitPrice>
     <Classification domain="UNSPSC">44000000</Classification>


### PR DESCRIPTION
Ref: https://github.com/officeluv/cxml-ruby/pull/16

Originally proposed by @CRiva

Currently, if the cxml passed in included a `<![CDATA[...]]>` tag
The parser would error out with this NoMethodError:

```
NoMethodError:
        undefined method `nodes' for #<Ox::CData:0x00007fee436eb070>
```

This fixes it such that the CDATA tag returns its value in the :content for the parent tag.