### PR TITLE
Add `Phone` DocumentNode

### DIFF
--- a/lib/cxml/country_code.rb
+++ b/lib/cxml/country_code.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CXML
+  class CountryCode < DocumentNode
+    accessible_attributes %i[
+      iso_country_code
+    ]
+  end
+end

--- a/lib/cxml/phone.rb
+++ b/lib/cxml/phone.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CXML
+  class Phone < DocumentNode
+    accessible_attributes %i[
+      name
+    ]
+
+    accessible_nodes %i[
+      telephone_number
+    ]
+  end
+end

--- a/lib/cxml/telephone_number.rb
+++ b/lib/cxml/telephone_number.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CXML
+  class TelephoneNumber < DocumentNode
+    accessible_nodes %i[
+      country_code
+      area_or_city_code
+      number
+    ]
+  end
+end

--- a/spec/fixtures/punch_out_setup_request_doc_with_ship_to.xml
+++ b/spec/fixtures/punch_out_setup_request_doc_with_ship_to.xml
@@ -39,6 +39,13 @@
 <Country isoCountryCode="US">United States</Country>
 </PostalAddress>
 <Email name="default">jmadden@coupa1.com</Email>
+<Phone name="work">
+  <TelephoneNumber>
+    <CountryCode isoCountryCode="US">1</CountryCode>
+    <AreaOrCityCode>855</AreaOrCityCode>
+    <Number>8671234</Number>
+  </TelephoneNumber>
+</Phone>
 </Address>
 </ShipTo>
 </PunchOutSetupRequest>

--- a/spec/punch_out_setup_request_spec.rb
+++ b/spec/punch_out_setup_request_spec.rb
@@ -38,6 +38,8 @@ describe CXML::PunchOutSetupRequest do
       doc = CXML::Document.new(data)
       doc.request.punch_out_setup_request.ship_to.should_not be_nil
       doc.request.punch_out_setup_request.ship_to.address.name.should_not be_nil
+      doc.request.punch_out_setup_request.ship_to.address.phone.should_not be_nil
+      doc.request.punch_out_setup_request.ship_to.address.phone.telephone_number.should_not be_nil
     end
   end
 


### PR DESCRIPTION
This PR adds `Phone`, `TelephoneNumber` & `CountryCode` DocumentNodes to be able to generate the <Phone> tag: 

`
<Phone name="work">
                     <TelephoneNumber>
                        <CountryCode isoCountryCode="US">1</CountryCode>
                        <AreaOrCityCode>855</AreaOrCityCode>
                        <Number>8671234</Number>
                     </TelephoneNumber>
                  </Phone>
`