### PR TITLE
Order of CXML produced

### DIFF
--- a/lib/cxml/punch_out_setup_request.rb
+++ b/lib/cxml/punch_out_setup_request.rb
@@ -5,12 +5,13 @@ module CXML
     accessible_attributes %i[
       operation
     ]
+
     accessible_nodes %i[
+      buyer_cookie
+      extrinsics
       browser_form_post
       supplier_setup
-      buyer_cookie
       ship_to
-      extrinsics
       contact
     ]
 


### PR DESCRIPTION
I found an issue when integrating punchout. The CXML produced is not compliant and is parsed incorrectly by certain providers. 

According to https://punchoutcommerce.com/tools/xml-validator, the cXML produced by the following code is invalid

```
doc = CXML::Document.new(parsed_hash)
doc.to_xml
```

However, by changing the order of the elements, it seems to work. 


The current cXML produced works with the majority of punchout partners but we recently came across one where changing the order of the accessible nodes worked. 

If there is any more work you would like done, please do not hesitate to ask. 

Thanks,
William

This commit orders the nodes to be compliant with the stricter punchout partners.

I may be missing something or misunderstanding something but I figured this PR might help other people who encounter this issue. 