### PR TITLE
Fix initializing child nodes when raise_unknown_elements is false

### DIFF
--- a/lib/cxml/document_node.rb
+++ b/lib/cxml/document_node.rb
@@ -121,9 +121,7 @@ module CXML
       klass = "CXML::#{camelize(key)}"
       send("#{key}=", Object.const_get(klass).new(val))
     rescue NoMethodError => e
-      raise(UnknownAttributeError, e) if CXML.raise_unknown_elements
-
-      CXML.logger.warn(e)
+      handle_unknown_elements_error(e)
     rescue NameError => e
       raise(e) unless e.to_s.match?(klass)
 
@@ -136,6 +134,8 @@ module CXML
       else
         send("#{key}=", val)
       end
+    rescue NoMethodError => e
+      handle_unknown_elements_error(e)
     end
 
     def camelize(string, uppercase_first_letter: true)
@@ -149,6 +149,12 @@ module CXML
       string.gsub(/_id(_)?$/, '_ID\1').gsub(%r{(?:_|(/))([a-z\d]*)}) do
         "#{Regexp.last_match(1)}#{Regexp.last_match(2).capitalize}"
       end.gsub('/', '::')
+    end
+
+    def handle_unknown_elements_error(error)
+      raise(UnknownAttributeError, error) if CXML.raise_unknown_elements
+
+      CXML.logger.warn(error)
     end
   end
 end

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -82,6 +82,26 @@ describe CXML::Document do
       end
     end
 
+    context 'when unknown attribute is present' do
+      let(:data) { CXML::Parser.new(data: fixture('document_node_with_unknown_attribute.xml')).parse }
+      let(:doc) { CXML::Document.new(data) }
+
+      it 'does not raise and parses child nodes if CXML.raise_unknown_elements is false' do
+        CXML.raise_unknown_elements = false
+        -> { doc }.should_not raise_error
+
+        doc.response.status.code.should eq(200)
+        doc.response.status.content.should eq('123456')
+
+        # Reset `raise_unknown_elements` for future tests
+        CXML.raise_unknown_elements = true
+      end
+
+      it 'raises UnknownAttributeError' do
+        -> { doc }.should raise_error(CXML::UnknownAttributeError)
+      end
+    end
+
     context 'when a response document is passed' do
       let(:data) { CXML::Parser.new(data: fixture('response_status_200.xml')).parse }
       include_examples :document_has_mandatory_values

--- a/spec/fixtures/document_node_with_unknown_attribute.xml
+++ b/spec/fixtures/document_node_with_unknown_attribute.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cXML SYSTEM "http://xml.cXML.org/schemas/cXML/1.2.020/cXML.dtd">
+<cXML xml:lang="en-US" payloadID="test-id" timestamp="2020-09-10T20:32:26+00:00">
+  <Response invalid="invalid">
+    <Status code="200" text="Ok">123456</Status>
+  </Response>
+</cXML>


### PR DESCRIPTION
Fixes #22 

This commit fixes a bug where child nodes are not initialized for a
node that has an unknown attribute, and raise_unknown_elements is false.