### PR TITLE
Add Ruby 3.0 Support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,13 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.6.x', '2.7.x', '3.0.x' ]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - name: Test with Rake
       run: |
         sudo apt-get install libxml2-utils

--- a/lib/cxml/document_node.rb
+++ b/lib/cxml/document_node.rb
@@ -35,7 +35,7 @@ module CXML
       data = data.serializable_hash if data.is_a?(self.class)
       return unless data.is_a?(Hash)
 
-      data.each(&method(:initialize_attribute))
+      data.each { |arr| initialize_attribute(*arr) }
     end
 
     def serializable_hash


### PR DESCRIPTION
There are some erros on Ruby 3.0.

```ruby
  1) CXML::Credential#initialize sets the attributes that are passed
     ArgumentError:
       wrong number of arguments (given 1, expected 2)
     # ./lib/cxml/document_node.rb:117:in `initialize_attribute'
```

It caused by auto splitting deprecation.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

> Splitting the last argument into positional and keyword parameters is deprecated

So I rewrote parameter splitting explicitly.