### PR TITLE
Explicitly specified the mode of Ox.load.

### DIFF
--- a/lib/cxml/parser.rb
+++ b/lib/cxml/parser.rb
@@ -19,7 +19,7 @@ module CXML
     end
 
     def document
-      doc = Ox.load(data)
+      doc = Ox.load(data, mode: :generic)
       @doc_type_string = doc.nodes.detect do |node|
         node.value&.match?(/^cXML /)
       end&.value


### PR DESCRIPTION
If the mode is not specified in Ox.load, there is a risk of object injection due to the mode being set to object depending on the xml value.
Depends on the gem loaded at runtime, but in the worst case RCE is possible.

Specifying the mode when using Ox.load avoids this risk.

```ruby
require 'ox'

class Cat
  def initialize(color)
    @color = color
  end
end

cat = Cat.new('white')

xml = Ox.dump(cat, :indent => 2)
puts xml
# <o c="Cat">
#   <s a="@color">white</s>
# </o>

puts Ox.load(xml)
# => <Ox::Element:0x00007f8b850f3328>

puts Ox.load(xml, :mode => :object)
# => #<Cat:0x00007f8b850f2db0>


xml = <<XML
<?ox mode="object" effort="strict" circular="false" xsd_date="false" ?>
<o c="Cat">
  <s a="@color">white</s>
</o>
XML

puts Ox.load(xml)
# => #<Cat:0x00007fae549c8d58>

puts Ox.load(xml, mode: :generic)
# => {:o=>{:s=>"white"}}
```